### PR TITLE
Update options.config

### DIFF
--- a/.ebextensions/options.config
+++ b/.ebextensions/options.config
@@ -3,5 +3,5 @@ option_settings:
     AWS_REGION: '`{"Ref" : "AWS::Region"}`'
   aws:elasticbeanstalk:container:nodejs:
     ProxyServer: nginx
-  aws:elasticbeanstalk:container:nodejs:staticfiles:
+  aws:elasticbeanstalk:environment:proxy:staticfiles:
     /static: /static


### PR DESCRIPTION
Fixed bug with EB on Amazon Linux 2 for Node.JS v16. The old version does not currently work with EB as Amazon Linux has changed (see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-specific.html#command-options-nodejs)